### PR TITLE
use custom access token to make release

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,4 +28,4 @@ jobs:
         with:
           release_branch: main
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
using a GITHUB_TOKEN to make a release prevents the on:release action from running, this fixes that.